### PR TITLE
FIX update solver output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Benchmark repository for Approximate Joint Diagonalization
 BenchOpt is a package to simplify and make more transparent and
 reproducible the comparisons of optimization algorithms.
 This benchmark considers the approximate joint diagonalization (AJD)
-of positive matrices. Given n square symmetric positive matrices $C^i$,
+of positive matrices. Given $n$ square symmetric positive matrices $C^i$,
 it consists of solving the following problem:
 
 $$

--- a/solvers/pham.py
+++ b/solvers/pham.py
@@ -27,4 +27,4 @@ class Solver(BaseSolver):
         self.B, _ = ajd_pham(self.C, max_iter=n_iter)
 
     def get_result(self):
-        return self.B
+        return dict(B=self.B)

--- a/solvers/qndiag.py
+++ b/solvers/qndiag.py
@@ -19,7 +19,7 @@ def loss_proxy(C, B):
 
 class Solver(BaseSolver):
     name = "qndiag"
-    stopping_strategy = "callback"
+    sampling_strategy = "callback"
 
     references = [
         "P. Ablin, J.F. Cardoso and A. Gramfort. Beyond Pham's algorithm"
@@ -67,9 +67,10 @@ class Solver(BaseSolver):
             Bu, _, Bv = np.linalg.svd(B)
             B = Bu @ Bv.T
 
+        self.B = B
         obj = loss_proxy(C, B)
 
-        while callback(B):
+        while callback():
             # Gradient
             D = B @ C @ B.T  # diagonalization with B
             diags = np.diagonal(D, axis1=1, axis2=2)

--- a/solvers/qndiag.py
+++ b/solvers/qndiag.py
@@ -95,4 +95,4 @@ class Solver(BaseSolver):
         self.B = B
 
     def get_result(self):
-        return self.B
+        return dict(B=self.B)


### PR DESCRIPTION
There is still an error in `qndiag`

```
Traceback (most recent call last):
  File "\benchopt\utils\pdb_helpers.py", line 28, in exception_handler
    yield ctx
  File "\benchopt\runner.py", line 125, in run_one_to_cvg
    cost = run_one_resolution_cached(stop_val=stop_val,
  File "\benchopt\benchmark.py", line 331, in _func_cached
    return func_cached(**kwargs)
  File "\joblib\memory.py", line 577, in __call__
    return self._cached_call(args, kwargs, shelving=False)[0]
  File "\joblib\memory.py", line 532, in _cached_call
    return self._call(call_id, args, kwargs, shelving)
  File "\joblib\memory.py", line 771, in _call
    output = self.func(*args, **kwargs)
  File "\benchopt\runner.py", line 50, in run_one_resolution
    solver.run(stop_val)
  File "\benchmark_jointdiag\solvers\qndiag.py", line 72, in run
    while callback(B):
TypeError: 'int' object is not callable
```

@pierreablin , do you know how to solve this problem?