### PR TITLE
Complete solvers for ajd

### DIFF
--- a/solvers/jade.py
+++ b/solvers/jade.py
@@ -2,11 +2,11 @@ from benchopt import BaseSolver
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
-    from pyriemann.utils.ajd import ajd_pham
+    from pyriemann.utils.ajd import rjd
 
 
 class Solver(BaseSolver):
-    name = "Pham"
+    name = "Jade"
 
     install_cmd = 'conda'
     requirements = ['pyriemann']
@@ -16,12 +16,12 @@ class Solver(BaseSolver):
         self.ortho = ortho
 
     def skip(self, C, ortho):
-        if ortho:
-            return True, "Pham does not support orthogonal constraint."
+        if not ortho:
+            return True, "Jade supports only orthogonal constraint."
         return False, None
 
     def run(self, n_iter):
-        self.B, _ = ajd_pham(self.C, n_iter_max=n_iter)
+        self.B, _ = rjd(self.C, n_iter_max=n_iter)
 
     def get_result(self):
         return dict(B=self.B)

--- a/solvers/qndiag.py
+++ b/solvers/qndiag.py
@@ -1,7 +1,6 @@
 from benchopt import BaseSolver
 from benchopt import safe_import_context
 
-
 with safe_import_context() as import_ctx:
     import numpy as np
     from scipy.linalg import expm

--- a/solvers/uwedge.py
+++ b/solvers/uwedge.py
@@ -2,11 +2,11 @@ from benchopt import BaseSolver
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
-    from pyriemann.utils.ajd import ajd_pham
+    from pyriemann.utils.ajd import uwedge
 
 
 class Solver(BaseSolver):
-    name = "Pham"
+    name = "U-WEDGE"
 
     install_cmd = 'conda'
     requirements = ['pyriemann']
@@ -17,11 +17,11 @@ class Solver(BaseSolver):
 
     def skip(self, C, ortho):
         if ortho:
-            return True, "Pham does not support orthogonal constraint."
+            return True, "U-WEDGE does not support orthogonal constraint."
         return False, None
 
     def run(self, n_iter):
-        self.B, _ = ajd_pham(self.C, n_iter_max=n_iter)
+        self.B, _ = uwedge(self.C, n_iter_max=n_iter)
 
     def get_result(self):
         return dict(B=self.B)


### PR DESCRIPTION
Complete solvers for ajd, adding `uwedge` (not ortho constraint) and `jade` (only ortho constraint) from pyRiemann