### PR TITLE
correct jade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ This benchmark can be run using the following commands:
    $ benchopt run ./benchmark_jointdiag
 
 
-Use `benchopt run -h` for more details about these options, or visit https://benchopt.github.io/api.html.
+Use `benchopt run -h` for more details about these options,
+or visit https://benchopt.github.io/stable/user_guide/API_ref.html.
 
 Troubleshooting
 ---------------

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -20,6 +20,7 @@ class Dataset(BaseDataset):
         self.n_features = n_features
         self.noise_level = noise_level
         self.random_state = random_state
+        self._used_seed = None
 
     def get_data(self):
         rng = np.random.RandomState(self.random_state)

--- a/solvers/jade.py
+++ b/solvers/jade.py
@@ -2,7 +2,13 @@ from benchopt import BaseSolver
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
-    from pyriemann.utils.ajd import rjd
+    import pyriemann
+    if pyriemann.__version__ < "0.13":
+        from pyriemann.utils.ajd import rjd as jade
+        transpose_out = True
+    else:
+        from pyriemann.geometry.ajd import jade
+        transpose_out = False
 
 
 class Solver(BaseSolver):
@@ -21,7 +27,9 @@ class Solver(BaseSolver):
         return False, None
 
     def run(self, n_iter):
-        self.B, _ = rjd(self.C, n_iter_max=n_iter)
+        self.B, _ = jade(self.C, n_iter_max=n_iter)
+        if transpose_out:
+            self.B = self.B.T
 
     def get_result(self):
         return dict(B=self.B)

--- a/solvers/pham.py
+++ b/solvers/pham.py
@@ -2,7 +2,11 @@ from benchopt import BaseSolver
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
-    from pyriemann.utils.ajd import ajd_pham
+    import pyriemann
+    if pyriemann.__version__ < "0.13":
+        from pyriemann.utils.ajd import ajd_pham
+    else:
+        from pyriemann.geometry.ajd import ajd_pham
 
 
 class Solver(BaseSolver):

--- a/solvers/uwedge.py
+++ b/solvers/uwedge.py
@@ -2,7 +2,11 @@ from benchopt import BaseSolver
 from benchopt import safe_import_context
 
 with safe_import_context() as import_ctx:
-    from pyriemann.utils.ajd import uwedge
+    import pyriemann
+    if pyriemann.__version__ < "0.13":
+        from pyriemann.utils.ajd import uwedge
+    else:
+        from pyriemann.geometry.ajd import uwedge
 
 
 class Solver(BaseSolver):


### PR DESCRIPTION
Correct `jade` transposing outputed diagonalizer, see https://github.com/pyRiemann/pyRiemann/pull/474#pullrequestreview-4743857248,
and take into account the renaming of module in pyRiemann.